### PR TITLE
Fix maxBodyLength limit

### DIFF
--- a/start.js
+++ b/start.js
@@ -46,6 +46,9 @@ var access_token = '';
 var scopes = 'data:read data:write data:create bucket:create bucket:read';
 const querystring = require('querystring');
 
+Axios.defaults.maxContentLength = Infinity;
+Axios.defaults.maxBodyLength = Infinity;
+
 // // Route /api/forge/oauth
 app.get('/api/forge/oauth', function (req, res) {
     Axios({


### PR DESCRIPTION
With Axios the body length limit defaults to 10 MB so uploading a larger file would end up with `Error: Request body larger than maxBodyLength limit`.

Tested and passed:
![image](https://user-images.githubusercontent.com/10786558/60639048-71c94200-9e53-11e9-8e5f-5c07c4de3526.png)
![image](https://user-images.githubusercontent.com/10786558/60639097-af2dcf80-9e53-11e9-9a23-aeb65babf46d.png)

