### PR TITLE
config request body size to Infinity

### DIFF
--- a/start.js
+++ b/start.js
@@ -182,7 +182,9 @@ app.post('/api/forge/datamanagement/bucket/upload', upload.single('fileToUpload'
                 'Content-Disposition': req.file.originalname,
                 'Content-Length': filecontent.length
             },
-            data: filecontent
+            data: filecontent,
+            maxContentLength: Infinity,
+            maxBodyLength: Infinity
         })
             .then(function (response) {
                 // Success


### PR DESCRIPTION
When we try to upload file, it always show the error message "Failed to create a new object in the bucket".

We found the limit size of axios request body is the root cause.

Hope to help someone faces the same issue !